### PR TITLE
Fix javadoc errors for building with Java SE 8

### DIFF
--- a/src/main/java/org/dynmap/DynmapCommonAPI.java
+++ b/src/main/java/org/dynmap/DynmapCommonAPI.java
@@ -22,7 +22,7 @@ public interface DynmapCommonAPI {
     public boolean markerAPIInitialized();
     /**
      * Send generic message to all web users
-     * @param sender - label for sender of message ("Message from <plugin>:") - if null, no from notice
+     * @param sender - label for sender of message ("Message from &lt;plugin&gt;:") - if null, no from notice
      * @param msg - message to be sent
      */
     public boolean sendBroadcastToWeb(String sender, String msg);

--- a/src/main/java/org/dynmap/markers/AreaMarker.java
+++ b/src/main/java/org/dynmap/markers/AreaMarker.java
@@ -38,7 +38,7 @@ public interface AreaMarker extends MarkerDescription {
     public double getCornerZ(int n);
     /**
      * Set coordinates of corner N
-     * @param n - index of corner: append new corner if >= corner count, else replace existing
+     * @param n - index of corner: append new corner if &gt;= corner count, else replace existing
      * @param x - x coordinate
      * @param z - z coordinate
      */

--- a/src/main/java/org/dynmap/markers/GenericMarker.java
+++ b/src/main/java/org/dynmap/markers/GenericMarker.java
@@ -16,7 +16,6 @@ public interface GenericMarker {
     public MarkerSet getMarkerSet();
     /**
      * Set the marker set for the marker
-     * @return marker set
      */
     public void setMarkerSet(MarkerSet newset);
     /**
@@ -47,8 +46,8 @@ public interface GenericMarker {
     public void setLabel(String lbl);
     /**
      * Update the marker's label and markup flag
-     * @param label - label string
-     * @param markup - if true, label is processed as HTML (innerHTML for <span> used for label); false implies plaintext
+     * @param lbl - label string
+     * @param markup - if true, label is processed as HTML (innerHTML for &lt;span&gt; used for label); false implies plaintext
      */
     public void setLabel(String lbl, boolean markup);
     /**
@@ -57,22 +56,22 @@ public interface GenericMarker {
     public boolean isLabelMarkup();
     /**
      * Get minimum zoom level for marker to be visible (overrides minzoom for marker set, if any)
-     * @return -1 if no minimum, >0 = lowest level of zoom marker is shown
+     * @return -1 if no minimum, &gt;0 = lowest level of zoom marker is shown
      */
     public int getMinZoom();
     /**
      * Set minimum zoom level for marker to be visible (overrides minzoom for marker set, if any)
-     * @param zoom : -1 if no minimum, >0 = lowest level of zoom marker is shown
+     * @param zoom : -1 if no minimum, &gt;0 = lowest level of zoom marker is shown
      */
     public void setMinZoom(int zoom);
     /**
      * Get maximum zoom level for marker to be visible (overrides maxzoom for marker set, if any)
-     * @return -1 if no maximum, >0 = highest level of zoom marker is shown
+     * @return -1 if no maximum, &gt;0 = highest level of zoom marker is shown
      */
     public int getMaxZoom();
     /**
      * Set maximum zoom level for marker to be visible (overrides maxzoom for marker set, if any)
-     * @param zoom : -1 if no maximum, >0 = highest level of zoom marker is shown
+     * @param zoom : -1 if no maximum, &gt;0 = highest level of zoom marker is shown
      */
     public void setMaxZoom(int zoom);
 }

--- a/src/main/java/org/dynmap/markers/MarkerSet.java
+++ b/src/main/java/org/dynmap/markers/MarkerSet.java
@@ -243,7 +243,7 @@ public interface MarkerSet {
     public void setLabelShow(Boolean show);
     /**
      * Get show/hide label for markers
-     * @returns true, show labels; false, hide (show on hover); null, use global default
+     * @return true, show labels; false, hide (show on hover); null, use global default
      */
     public Boolean getLabelShow();
     /**
@@ -253,7 +253,7 @@ public interface MarkerSet {
     public void setDefaultMarkerIcon(MarkerIcon defmark);
     /**
      * Get the default marker icon for the markers added to this set
-     * @returns default marker
+     * @return default marker
      */
     public MarkerIcon getDefaultMarkerIcon();
 }

--- a/src/main/java/org/dynmap/markers/PlayerSet.java
+++ b/src/main/java/org/dynmap/markers/PlayerSet.java
@@ -5,7 +5,7 @@ import java.util.Set;
 /**
  * Interface defining a set of players that can be made visible on the map to other players with the needed permissions.
  * The set can have symmetric access - meaning that any player in the set can see the other players in the set.
- * In any case, players with the permission node 'dynmap.playerset.<set-id>' can see players in the set.
+ * In any case, players with the permission node 'dynmap.playerset.&lt;set-id&gt;' can see players in the set.
  */
 public interface PlayerSet {
     /**

--- a/src/main/java/org/dynmap/markers/PolyLineMarker.java
+++ b/src/main/java/org/dynmap/markers/PolyLineMarker.java
@@ -28,7 +28,7 @@ public interface PolyLineMarker extends MarkerDescription {
     public double getCornerZ(int n);
     /**
      * Set coordinates of corner N
-     * @param n - index of corner: append new corner if >= corner count, else replace existing
+     * @param n - index of corner: append new corner if &gt;= corner count, else replace existing
      * @param x - x coordinate
      * @param y - y coordinate
      * @param z - z coordinate

--- a/src/main/java/org/dynmap/modsupport/ModModelDefinition.java
+++ b/src/main/java/org/dynmap/modsupport/ModModelDefinition.java
@@ -21,57 +21,57 @@ public interface ModModelDefinition {
     public ModTextureDefinition getTextureDefinition();
     /**
      * Add volumetric model : default assumes all metadata values are matching
-     * @param blockID - block ID 
+     * @param blockid - block ID
      * @param scale - grid scale (subblock array is scale x scale x scale) : from 1 to 16
      * @return block model: use methods to set occupied subblocks
      */
     public VolumetricBlockModel addVolumetricModel(int blockid, int scale);
     /**
      * Add standard stair model : default assumes all metadata values are matching
-     * @param blockID - block ID 
+     * @param blockid - block ID
      * @return block model record
      */
     public StairBlockModel addStairModel(int blockid);
     /**
      * Add wall or fence model : default assumes all metadata values are matching
-     * @param blockID - block ID 
+     * @param blockid - block ID
      * @param type - type of wall or fence
      * @return block model record
      */
     public WallFenceBlockModel addWallFenceModel(int blockid, WallFenceBlockModel.FenceType type);
     /**
      * Add cuboid model : default assumes all metadata values are matching
-     * @param blockID - block ID 
+     * @param blockid - block ID
      * @return block model record
      */
     public CuboidBlockModel addCuboidModel(int blockid);
     /**
      * Add pane model : default assumes all metadata values are matching
-     * @param blockID - block ID 
+     * @param blockid - block ID
      * @return block model record
      */
     public PaneBlockModel addPaneModel(int blockid);
     /**
      * Add standard plant model : default assumes all metadata values are matching
-     * @param blockID - block ID 
+     * @param blockid - block ID
      * @return block model record
      */
     public PlantBlockModel addPlantModel(int blockid);
     /**
      * Add standard box model : default assumes all metadata values are matching
-     * @param blockID - block ID 
+     * @param blockid - block ID
      * @return block model record
      */
     public BoxBlockModel addBoxModel(int blockid);
     /**
      * Add patch box model : default assumes all metadata values are matching
-     * @param blockID - block ID 
+     * @param blockid - block ID
      * @return block model record
      */
     public PatchBlockModel addPatchModel(int blockid);
     /**
      * Add rotated patch box model, based on existing model : default assumes all metadata values are matching
-     * @param blockID - block ID 
+     * @param blockid - block ID
      * @param model - existing model to be rotated
      * @param xrot - x rotation in degrees (0, 90, 180, 270)
      * @param yrot - y rotation in degrees (0, 90, 180, 270)

--- a/src/main/java/org/dynmap/modsupport/ModTextureDefinition.java
+++ b/src/main/java/org/dynmap/modsupport/ModTextureDefinition.java
@@ -27,7 +27,7 @@ public interface ModTextureDefinition {
     public boolean publishDefinition();
     
     /**
-     * Set texture path for texture resources (base path for resource loads from mod - for 1.6.x, default is assets/<modid>/textures/blocks)
+     * Set texture path for texture resources (base path for resource loads from mod - for 1.6.x, default is assets/&lt;modid&gt;/textures/blocks)
      * @param txtpath - texture resource base path
      */
     public void setTexturePath(String txtpath);
@@ -85,7 +85,7 @@ public interface ModTextureDefinition {
      * @param id - texture ID
      * @param filename - texture file name (including .png)
      * @param xcount - horizontal patch count in texture file
-     * @param ycound - vertical patch count in texture file
+     * @param ycount - vertical patch count in texture file
      * @return TextureFile associated with resource
      */
     public GridTextureFile registerGridTextureFile(String id, String filename, int xcount, int ycount);
@@ -96,7 +96,7 @@ public interface ModTextureDefinition {
      * @param id - texture ID
      * @param filename - texture file name (including .png)
      * @param xcount - horizontal patch count in texture file
-     * @param ycound - vertical patch count in texture file
+     * @param ycount - vertical patch count in texture file
      * @return CustomTextureFile associated with resource: use methods on this to define the custom patches within the file
      */
     public CustomTextureFile registerCustomTextureFile(String id, String filename, int xcount, int ycount);

--- a/src/main/java/org/dynmap/modsupport/PatchBlockModel.java
+++ b/src/main/java/org/dynmap/modsupport/PatchBlockModel.java
@@ -9,8 +9,8 @@ public interface PatchBlockModel extends BlockModel {
     /**
      * Add patch with given attributes.
      * 
-     * Definition is a 2D parallelogram surface, with origin <x0,y0,z0> within the block, and defined by two edge vectors -
-     * one with and end point of <xu,yu,zu>, and a second with an end point of <xv,yv,zv>.  The patch is
+     * Definition is a 2D parallelogram surface, with origin &lt;x0,y0,z0&gt; within the block, and defined by two edge vectors -
+     * one with and end point of &lt;xu,yu,zu&gt;, and a second with an end point of &lt;xv,yv,zv&gt;.  The patch is
      * defined within the unit vector range umin to umax (parallel to the U vecotr) and vmin to vmax
      * (parallel to the V vector).
      * The surface can be visible via one side (SideVisible.TOP, SideVisible.BOTTOM) or both sides (SideVisible.BOTH).
@@ -28,7 +28,7 @@ public interface PatchBlockModel extends BlockModel {
      * @param umax - upper bound for visibility along U vector (use 1.0 by default)
      * @param vmin - lower bound for visibility along V vector (use 0.0 by default)
      * @param vmax - upper bound for visibility along V vector (use 1.0 by default)
-     * @param uplusvmax - upper bound for visibility for U+V (use 100.0 by default: <=1.0 for triangle)
+     * @param uplusvmax - upper bound for visibility for U+V (use 100.0 by default: &lt;=1.0 for triangle)
      * @param sidevis - Controls which sides of the surface are visible (U cross V defines normal - TOP is from that side, BOTTOM is opposite side)
      * @return patch ID
      */
@@ -38,8 +38,8 @@ public interface PatchBlockModel extends BlockModel {
     /**
      * Add patch with given attributes.
      * 
-     * Definition is a 2D parallelogram surface, with origin <x0,y0,z0> within the block, and defined by two edge vectors -
-     * one with and end point of <xu,yu,zu>, and a second with an end point of <xv,yv,zv>.  The patch is
+     * Definition is a 2D parallelogram surface, with origin &lt;x0,y0,z0&gt; within the block, and defined by two edge vectors -
+     * one with and end point of &lt;xu,yu,zu&gt;, and a second with an end point of &lt;xv,yv,zv&gt;.  The patch is
      * defined within the unit vector range 0.0 to 1.0 (parallel to the U vecotr) and 0.0 to 1.0
      * (parallel to the V vector).
      * The surface can be visible via one side (SideVisible.TOP, SideVisible.BOTTOM) or both sides (SideVisible.BOTH).
@@ -61,8 +61,8 @@ public interface PatchBlockModel extends BlockModel {
     /**
      * Add patch with given attributes.
      * 
-     * Definition is a 2D parallelogram surface, with origin <x0,y0,z0> within the block, and defined by two edge vectors -
-     * one with and end point of <xu,yu,zu>, and a second with an end point of <xv,yv,zv>.  The patch is
+     * Definition is a 2D parallelogram surface, with origin &lt;x0,y0,z0&gt; within the block, and defined by two edge vectors -
+     * one with and end point of &lt;xu,yu,zu&gt;, and a second with an end point of &lt;xv,yv,zv&gt;.  The patch is
      * defined within the unit vector range 0.0 to 1.0 (parallel to the U vecotr) and 0.0 to 1.0
      * (parallel to the V vector).
      * The surface is visible on both sides

--- a/src/main/java/org/dynmap/permissions/PermissionsHandler.java
+++ b/src/main/java/org/dynmap/permissions/PermissionsHandler.java
@@ -50,7 +50,7 @@ public abstract class PermissionsHandler {
     /**
      * Test if given (potentially offline) user has the given permission
      * 
-     * @param username - user name
+     * @param player - user name
      * @param perm - permission
      * @return true if has permission, false if not
      */

--- a/src/main/java/org/dynmap/renderer/CustomRenderer.java
+++ b/src/main/java/org/dynmap/renderer/CustomRenderer.java
@@ -118,7 +118,7 @@ public abstract class CustomRenderer {
      * Get patch corresponding to side N (per MC side index: 0=bottom (y-), 1=top (y+), 2=z-, 3=z+, 4=x-, 5=x+)
      * @param rpf - patch factory
      * @param side - side number
-     * @paran setback - amount face is set back from block edge (0=on side, 0.5=at middle)
+     * @param setback - amount face is set back from block edge (0=on side, 0.5=at middle)
      * @param umin - texture horizontal minimum
      * @param umax - texture horizontal maximum
      * @param vmin - texture vertical minimum

--- a/src/main/java/org/dynmap/renderer/RenderPatchFactory.java
+++ b/src/main/java/org/dynmap/renderer/RenderPatchFactory.java
@@ -6,8 +6,8 @@ public interface RenderPatchFactory {
     /**
      * Get/create patch with given attributes.
      * 
-     * Definition is a 2D parallelogram surface, with origin <x0,y0,z0> within the block, and defined by two edge vectors -
-     * one with and end point of <xu,yu,zu>, and a second with an end point of <xv,yv,zv>.  The patch is
+     * Definition is a 2D parallelogram surface, with origin &lt;x0,y0,z0&gt; within the block, and defined by two edge vectors -
+     * one with and end point of &lt;xu,yu,zu&gt;, and a second with an end point of &lt;xv,yv,zv&gt;.  The patch is
      * defined within the unit vector range umin to umax (parallel to the U vecotr) and vmin to vmax
      * (parallel to the V vector).
      * The surface can be visible via one side (SideVisible.TOP, SideVisible.BOTTOM) or both sides (SideVisible.BOTH).
@@ -29,12 +29,12 @@ public interface RenderPatchFactory {
      * @param sidevis - Controls which sides of the surface are visible (U cross V defines normal - TOP is from that side, BOTTOM is opposite side)
      * @param textureidx - texture index to be used for patch
      */
-    public RenderPatch getPatch(double x0, double y0, double z0, double xu, double yu, double zu, double xv, double yv, double zv, double unin, double umax, double vmin, double vmax, SideVisible sidevis, int textureids);
+    public RenderPatch getPatch(double x0, double y0, double z0, double xu, double yu, double zu, double xv, double yv, double zv, double umin, double umax, double vmin, double vmax, SideVisible sidevis, int textureidx);
     /**
      * Get/create patch with given attributes.
      * 
-     * Definition is a 2D triangular surface, with origin <x0,y0,z0> within the block, and defined by two edge vectors -
-     * one with and end point of <xu,yu,zu>, and a second with an end point of <xv,yv,zv>.  The visibility of
+     * Definition is a 2D triangular surface, with origin &lt;x0,y0,z0&gt; within the block, and defined by two edge vectors -
+     * one with and end point of &lt;xu,yu,zu&gt;, and a second with an end point of &lt;xv,yv,zv&gt;.  The visibility of
      * the patch is limited to the sum of the unit vector values for U and V via uplusvmax.
      * The surface can be visible via one side (SideVisible.TOP, SideVisible.BOTTOM) or both sides (SideVisible.BOTH).
      * The surface also needs to define the index of the texture to be used for shading the surface.
@@ -48,11 +48,11 @@ public interface RenderPatchFactory {
      * @param xv - X coordinate of end of V vector
      * @param yv - Y coordinate of end of V vector
      * @param zv - Z coordinate of end of V vector
-     * #param uplusvmax - limit on sum of unit vectors for U and V (use 1.0 for triangle extending from origin to U and to V)
+     * @param uplusvmax - limit on sum of unit vectors for U and V (use 1.0 for triangle extending from origin to U and to V)
      * @param sidevis - Controls which sides of the surface are visible (U cross V defines normal - TOP is from that side, BOTTOM is opposite side)
      * @param textureidx - texture index to be used for patch
      */
-    public RenderPatch getPatch(double x0, double y0, double z0, double xu, double yu, double zu, double xv, double yv, double zv, double uplusvmax, SideVisible sidevis, int textureids);
+    public RenderPatch getPatch(double x0, double y0, double z0, double xu, double yu, double zu, double xv, double yv, double zv, double uplusvmax, SideVisible sidevis, int textureidx);
     /**
      * Get/create patch with given attributes.
      * 
@@ -82,7 +82,7 @@ public interface RenderPatchFactory {
      * Get index of texture from texture map, using given key value
      * @param id - texture map ID
      * @param key - key of requested texture
-     * @returns index of texture, or -1 if not found
+     * @return index of texture, or -1 if not found
      */
     public int getTextureIndexFromMap(String id, int key);
     /**


### PR DESCRIPTION
More information about doclint (which is what checks syntax for javadoc comments) can be found here:
http://openjdk.java.net/jeps/172
