### PR TITLE
Fix webChatEvent being called only for the first message sent

### DIFF
--- a/src/main/java/org/dynmap/DynmapCommonAPIListener.java
+++ b/src/main/java/org/dynmap/DynmapCommonAPIListener.java
@@ -93,7 +93,6 @@ public abstract class DynmapCommonAPIListener {
             for (DynmapCommonAPIListener l : listeners) {
                 noCancel = l.webChatEvent(source, name, message) && noCancel;
             }
-            dynmapapi = null;
         }
         return noCancel;
     }


### PR DESCRIPTION
Looks like it was just a copy-paste 'typo', dynmapapi is clearly not supposed to be set to null here.

Fixes #2.