### PR TITLE
1.11 support - DynmapCoreAPI

### DIFF
--- a/src/main/java/org/dynmap/modsupport/ModTextureDefinition.java
+++ b/src/main/java/org/dynmap/modsupport/ModTextureDefinition.java
@@ -81,6 +81,13 @@ public interface ModTextureDefinition {
      */
     public SkinTextureFile registerSkinTextureFile(String id, String filename);
     /**
+     * Register texture file with SHULKER layout (standard shulker and shulker box texture)
+     * @param id - texture ID
+     * @param filename - texture file name (including .png)
+     * @return TextureFile associated with resource
+     */
+    public ShulkerTextureFile registerShulkerTextureFile(String id, String filename);
+    /**
      * Register texture file with GRID layout (array of xcount x ycount square textures)
      * @param id - texture ID
      * @param filename - texture file name (including .png)

--- a/src/main/java/org/dynmap/modsupport/ShulkerTextureFile.java
+++ b/src/main/java/org/dynmap/modsupport/ShulkerTextureFile.java
@@ -1,0 +1,5 @@
+package org.dynmap.modsupport;
+
+public interface ShulkerTextureFile extends TextureFile {
+
+}

--- a/src/main/java/org/dynmap/modsupport/TextureFileType.java
+++ b/src/main/java/org/dynmap/modsupport/TextureFileType.java
@@ -6,6 +6,7 @@ public enum TextureFileType {
     BIGCHEST,   // Standard double chest texture
     SIGN,       // Standard signpost texture
     SKIN,       // Standard player or humanoid model texture (zombie, skeleton)
+    SHULKER,    // Standard shulker and shulker box texture
     CUSTOM,     // Custom patch layout in texture
     BIOME       // Biome color map (256 x 256)
 }


### PR DESCRIPTION
*For the DynmapCore 1.11 pull request, see https://github.com/webbukkit/DynmapCore/pull/74*

![Orange Shulker texture map](http://i.imgur.com/IXKRIdn.png)

This PR adds support for `ShulkerTextureFile`, which is needed for 1.11 support in Dynmap. This is intended for the texture maps that map onto [1.11's shulker boxes](http://minecraft.gamepedia.com/Shulker_Box).